### PR TITLE
Add node_name field in srv Request

### DIFF
--- a/mros2_reasoner/mros2_reasoner/ros_reasoner.py
+++ b/mros2_reasoner/mros2_reasoner/ros_reasoner.py
@@ -222,6 +222,10 @@ class RosReasoner(Node, Reasoner):
         self.req = ChangeMode.Request()
 
         self.req.mode_name = new_configuration
+
+        # node_name field is necessary in system_modes feature/rules branch but incompatible with master
+        self.req.node_name = self.node_name
+        
         # async call, but the follow up while loop BLOCKS execution till there is a response
         mode_change_srv_call_future = self.system_modes_cli.call_async(self.req)
 


### PR DESCRIPTION
Hi @marioney !

The feature/rules branch of system modes uses an old version of its service messages in which ChangeModeRequest needs the node_name field. It is not necessary (maybe you get a compilation error) if you use the master branch, but we need it if we want to show the laser failure and the battery contingency in the MROS hands-on.

- I have added the node_name into the ChangeModeRequest message.